### PR TITLE
Perf optimization

### DIFF
--- a/vm-agent/monitoring-agent/meminfoparser.h
+++ b/vm-agent/monitoring-agent/meminfoparser.h
@@ -1,9 +1,6 @@
 #include <fstream>
 #include <iostream>
-#include <numeric>
-#include <unistd.h>
-#include <vector>
-#include <memory>
+
 
 class meminfoparser
 {

--- a/vm-agent/monitoring-agent/procstatparser.h
+++ b/vm-agent/monitoring-agent/procstatparser.h
@@ -1,9 +1,6 @@
 #include <fstream>
 #include <iostream>
-#include <numeric>
-#include <unistd.h>
-#include <vector>
-#include <memory>
+
 
 class procstatparser
 {


### PR DESCRIPTION
Faster reading of `/proc/meminfo` and `/proc/stat` by only reading the necessary fields. 

Savings are marginal for the current reading interval (~20-30us every 100ms). If we increased the frequency of reading resource usage in the future, the gains will be more visible. Also, always good to spend fewer CPU cycles on host agents, as those precious cycles can be used for offloading. 