### PR TITLE
Handle error of missing pubsub message size data 

### DIFF
--- a/scheduler/Estimator.py
+++ b/scheduler/Estimator.py
@@ -360,10 +360,22 @@ class Estimator:
         for func in self.workflowFunctions:
             if func != self.initFunc:
                 selectedtopic = self.topics[self.workflowFunctions.index(func)]
-                psSize = pubsubsizeDF.loc[
+                psSizeSeries = pubsubsizeDF.loc[
                     pubsubsizeDF["Topic"] == selectedtopic, "PubsubMsgSize"
-                ].item()
-                pubSubSize[func] = psSize
+                ]
+                if len(psSizeSeries) == 0:
+                    pubSubSize[func] = 0
+                else:
+                    psSize = psSizeSeries.item()
+                    pubSubSize[func] = psSize
+        nonzero_vals = [ pubSubSize[func] for func in pubSubSize.keys() if pubSubSize[func] != 0 ]
+        if len(nonzero_vals) != 0:
+            average_nonzeroes = np.mean(np.array(nonzero_vals))
+            for func in pubSubSize.keys():
+                if pubSubSize[func] == 0:
+                    pubSubSize[func] = average_nonzeroes
+        else:
+            print("No prior data on pub/sub message size yet!")
         with open(
             (
                 (os.path.dirname(os.path.abspath(__file__)))


### PR DESCRIPTION
This error occurs when there is no prior data on the message size of pubsub topics of different functions in the workflow. In this PR, I handled this error by:
1. If there is no history on a specific topic of the workflow first assume 0 message size.
2. By getting pubsub message size of all the topics in the workflow, see if we were able to get any non-zero message size (meaning that prior data were available for them)
3. In that case replace all topics of the workflow with 0 pubsub message size, with the average of non-zero message sizes of other topics in the workflow. 
4. Otherwise, if there is no prior data for all the topics, assume zero message size for all the topics for now, every time we get the serverless logs, we will also get the updated message sizes, and at some point, we will be able to have data on them, but for now assume 0 for them.